### PR TITLE
Fix formatting for SpiralTriggerAgent

### DIFF
--- a/syos_recursive_agent/SpiralTriggerAgent.ts
+++ b/syos_recursive_agent/SpiralTriggerAgent.ts
@@ -1,4 +1,5 @@
-import { SymbolicDecayManager } from './SymbolicDecayManager';/**
+import { SymbolicDecayManager } from './SymbolicDecayManager';
+/**
  * SpiralTriggerAgent.ts
  * Detects symbolic loops and triggers corrective actions
  */
@@ -66,9 +67,9 @@ export class SpiralTriggerAgent {
 
   runSpiral(): void {
     this.logger("[SpiralTriggerAgent] Starting spiral loop detection and correction...");
-const decayManager = new SymbolicDecayManager(this.memory);
-decayManager.applyDecay(0.5); // Decay rate can be adjusted
-this.logger("Applied symbolic decay before loop detection.");
+    const decayManager = new SymbolicDecayManager(this.memory);
+    decayManager.applyDecay(0.5); // Decay rate can be adjusted
+    this.logger("Applied symbolic decay before loop detection.");
     if (this.detectLoops(this.memory)) {
       this.correctDrift();
     } else {


### PR DESCRIPTION
## Summary
- properly separate import from doc block in `SpiralTriggerAgent.ts`
- indent decay manager usage within `runSpiral`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68688c54ff608323b20a2e0df99ee42d