### PR TITLE
Fix SpiralTriggerAgent import style

### DIFF
--- a/syos_recursive_agent/SpiralTriggerAgent.ts
+++ b/syos_recursive_agent/SpiralTriggerAgent.ts
@@ -1,4 +1,4 @@
-import { SymbolicDecayManager } from './SymbolicDecayManager';
+import { SymbolicDecayManager } from "./SymbolicDecayManager";
 
 /**
  * SpiralTriggerAgent.ts


### PR DESCRIPTION
## Summary
- tweak import quoting in `SpiralTriggerAgent`
- keep documentation block separated from imports
- maintain indenting of decay manager lines in `runSpiral`

## Testing
- `ts-node syos_recursive_agent/test/RunSpiralTest.ts`

------
https://chatgpt.com/codex/tasks/task_e_686920f18ccc8323acc68c125c16b718