### PR TITLE
Add syos_dapp_ui React template

### DIFF
--- a/syos_dapp_ui/index.html
+++ b/syos_dapp_ui/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SYOS Dashboard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/syos_dapp_ui/package.json
+++ b/syos_dapp_ui/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "syos-dashboard",
+  "version": "0.0.1",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "ethers": "^6.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.10.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.0.0",
+    "vite": "^4.0.0"
+  }
+}

--- a/syos_dapp_ui/src/App.tsx
+++ b/syos_dapp_ui/src/App.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import Wallet from './components/Wallet';
+import MemoryLog from './components/MemoryLog';
+import DriftChart from './components/DriftChart';
+
+const App = () => {
+  const dashboard = (
+    <div>
+      <h1>SYOS Dashboard</h1>
+      <Wallet />
+      <MemoryLog />
+      <DriftChart />
+    </div>
+  );
+
+  return (
+    <Router>
+      <Routes>
+        <Route path="/" element={dashboard} />
+        <Route path="*" element={dashboard} />
+      </Routes>
+    </Router>
+  );
+};
+
+export default App;

--- a/syos_dapp_ui/src/components/DriftChart.tsx
+++ b/syos_dapp_ui/src/components/DriftChart.tsx
@@ -1,0 +1,8 @@
+export default function DriftChart() {
+  return (
+    <div>
+      <h2>Drift Prediction Chart</h2>
+      <p>[Drift analytics will be visualized here]</p>
+    </div>
+  );
+}

--- a/syos_dapp_ui/src/components/MemoryLog.tsx
+++ b/syos_dapp_ui/src/components/MemoryLog.tsx
@@ -1,0 +1,8 @@
+export default function MemoryLog() {
+  return (
+    <div>
+      <h2>Symbolic Memory Log</h2>
+      <p>[Placeholder for SYOS memory snapshots]</p>
+    </div>
+  );
+}

--- a/syos_dapp_ui/src/components/Wallet.tsx
+++ b/syos_dapp_ui/src/components/Wallet.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+import { ethers } from 'ethers';
+
+export default function Wallet() {
+  const [account, setAccount] = useState<string | null>(null);
+
+  async function connect() {
+    if (window.ethereum) {
+      const [addr] = await window.ethereum.request({ method: 'eth_requestAccounts' });
+      setAccount(addr);
+    }
+  }
+
+  useEffect(() => {
+    if (window.ethereum) {
+      connect();
+    }
+  }, []);
+
+  return (
+    <div>
+      <h2>Wallet</h2>
+      <p>Connected: {account ? account : 'Not Connected'}</p>
+    </div>
+  );
+}

--- a/syos_dapp_ui/src/main.tsx
+++ b/syos_dapp_ui/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/syos_dapp_ui/tsconfig.json
+++ b/syos_dapp_ui/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}

--- a/syos_dapp_ui/vite.config.ts
+++ b/syos_dapp_ui/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  base: '/',
+  plugins: [react()],
+  server: {
+    port: 5173
+  }
+});


### PR DESCRIPTION
## Summary
- add minimal Vite React project under `syos_dapp_ui`
- include wallet connect UI, memory log and drift chart components
- configure router with fallback
- set up TypeScript and Vite configuration for development

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686925af49608323a3faa76c4c7c0044