### PR TITLE
Add vscode import to memoryManager

### DIFF
--- a/syos-vscode-extension/src/logic/memoryManager.ts
+++ b/syos-vscode-extension/src/logic/memoryManager.ts
@@ -1,3 +1,5 @@
+import * as vscode from 'vscode';
+
 export async function getSymbolicPrompt(): Promise<string> {
   const prompts = [
     "SYOS: What do I almost say but don’t?",


### PR DESCRIPTION
## Summary
- import `vscode` namespace in `memoryManager.ts`
- built extension to verify file compiles

## Testing
- `npm run compile` *(fails: Property 'joinPath' does not exist on type 'typeof Uri')*
- `npx tsc syos-vscode-extension/src/logic/memoryManager.ts --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6869b3cff8d08323ab61677dad6f7e1d