### PR TITLE
Add drift API and update Vercel routing

### DIFF
--- a/syos_dapp_ui/api/drift.ts
+++ b/syos_dapp_ui/api/drift.ts
@@ -1,0 +1,18 @@
+import { VercelRequest, VercelResponse } from '@vercel/node';
+
+export default function handler(req: VercelRequest, res: VercelResponse) {
+  // Mocked drift data based on Codex plan example
+  const data = {
+    timeline: ['loop-1', 'loop-2'],
+    driftLogs: [
+      { drift: 0.2, correction: 'increase symbolic weight' },
+      { drift: -0.3, correction: 'reduce anchor priority' }
+    ],
+    agentActions: [
+      { time: 'T1', action: 'inject', rating: 0.9 },
+      { time: 'T2', action: 'visualize', rating: 1.0 }
+    ]
+  };
+
+  res.status(200).json(data);
+}

--- a/syos_dapp_ui/vercel.json
+++ b/syos_dapp_ui/vercel.json
@@ -1,3 +1,6 @@
 {
-  "rewrites": [{ "source": "/*", "destination": "/index.html" }]
+  "rewrites": [
+    { "source": "/api/:path*", "destination": "/api/:path*" },
+    { "source": "/:path*", "destination": "/index.html" }
+  ]
 }


### PR DESCRIPTION
## Summary
- implement `/api/drift` serverless function with mocked data
- route `/api/*` through Vercel config to avoid SPA rewrite

## Testing
- `npm --prefix syos_dapp_ui run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869b14b786c8323aee846e7b65abd66