### PR TITLE
Add auto deploy workflow

### DIFF
--- a/.github/workflows/vercel_production.yml
+++ b/.github/workflows/vercel_production.yml
@@ -1,0 +1,23 @@
+name: Deploy to Vercel
+
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Deploy
+        uses: amondnet/vercel-action@v25.2.0
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          working-directory: ./syos_dapp_ui
+          prod: true
+

--- a/README.md
+++ b/README.md
@@ -55,3 +55,15 @@ Then access endpoints like `http://localhost:3000/api/drift`.
 ```bash
 git checkout -b feature/wallet-integration
 ```
+
+## Production Deployment
+
+Merges to `main` automatically deploy to Vercel using the `Deploy to Vercel` workflow.
+Add these repository secrets so the workflow can authenticate:
+
+- `VERCEL_TOKEN` – Vercel access token
+- `VERCEL_ORG_ID` – organization ID
+- `VERCEL_PROJECT_ID` – project ID for the dashboard
+
+Once configured, pushes to `main` redeploy https://syos-system-fin.vercel.app.
+


### PR DESCRIPTION
## Summary
- deploy from main automatically via GitHub Actions
- document new Vercel action in the README

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869c08a707c8323bcfeb59c5c20e6f1