### PR TITLE
docs: note on Vite and npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ npm install        # install dependencies
 npm run dev        # start the Vite dev server at http://localhost:5173
 ```
 
+> **Note**: Run `npm install` in `syos_dapp_ui` before executing `npm run dev` or
+> `npm run build`. Vite is the build tool used by this project and is included in
+> the `devDependencies` section of `package.json`.
+
 ### Serverless functions
 
 Functions placed in `syos_dapp_ui/api` are deployed on Vercel under `/api/*`. To test them locally you can use the Vercel CLI:


### PR DESCRIPTION
## Summary
- clarify that `npm install` is required before running the dev server
- mention Vite as the build tool in `devDependencies`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6869eeee40e483238c498554b5ea2da2