### PR TITLE
Update README with dependency and build notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,15 @@ This repository contains the pieces that power the Symbolic Yield Observation Sy
 
 ## Running the DApp
 
+Make sure to install dependencies inside `syos_dapp_ui` before running
+`npm run dev` or `npm run build`. Vite is used as the build tool and is
+listed in the project's `devDependencies`.
+
 ```bash
 cd syos_dapp_ui
 npm install        # install dependencies
 npm run dev        # start the Vite dev server at http://localhost:5173
+# npm run build    # create a production build
 ```
 
 ### Serverless functions


### PR DESCRIPTION
## Summary
- document installing dependencies before running the UI
- mention that Vite is used for building and is part of `devDependencies`

## Testing
- `npm install` within `syos_dapp_ui`
- `npm run build` within `syos_dapp_ui`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6869ea4c43f08323a1b1972e0eb98e5e