### PR TITLE
Add neon theme and price chart

### DIFF
--- a/syos_dapp_ui/index.html
+++ b/syos_dapp_ui/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>SYOS Dashboard</title>
+    <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@500&display=swap" rel="stylesheet">
   </head>
   <body>
     <div id="root"></div>

--- a/syos_dapp_ui/package-lock.json
+++ b/syos_dapp_ui/package-lock.json
@@ -11,8 +11,10 @@
         "@solana/wallet-adapter-react": "^0.15.39",
         "@solana/wallet-adapter-react-ui": "^0.9.39",
         "@solana/wallet-adapter-wallets": "^0.19.37",
+        "chart.js": "^4.5.0",
         "ethers": "^6.0.0",
         "react": "^18.2.0",
+        "react-chartjs-2": "^5.3.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.10.0"
       },
@@ -1582,6 +1584,12 @@
         "bs58": "^5.0.0",
         "uuid": "^8.3.2"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@ledgerhq/devices": {
       "version": "8.4.7",
@@ -9458,6 +9466,18 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
+    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -13829,6 +13849,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz",
+      "integrity": "sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-devtools-core": {

--- a/syos_dapp_ui/package.json
+++ b/syos_dapp_ui/package.json
@@ -7,13 +7,15 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@solana/wallet-adapter-react": "^0.15.39",
+    "@solana/wallet-adapter-react-ui": "^0.9.39",
+    "@solana/wallet-adapter-wallets": "^0.19.37",
+    "chart.js": "^4.5.0",
     "ethers": "^6.0.0",
     "react": "^18.2.0",
+    "react-chartjs-2": "^5.3.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.10.0",
-    "@solana/wallet-adapter-react": "^0.15.39",
-    "@solana/wallet-adapter-wallets": "^0.19.37",
-    "@solana/wallet-adapter-react-ui": "^0.9.39"
+    "react-router-dom": "^6.10.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.11",

--- a/syos_dapp_ui/src/App.tsx
+++ b/syos_dapp_ui/src/App.tsx
@@ -1,16 +1,35 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import WalletDisplay from "./components/WalletDisplay";
 import MemoryLog from "./components/MemoryLog";
 import DriftChart from "./components/DriftChart";
+import PriceChart from "./components/PriceChart";
 
 const App = () => {
+  const [btcHistory, setBtcHistory] = useState<number[]>([]);
+
+  async function fetchBTCPrice(): Promise<number> {
+    const res = await fetch('https://api.coindesk.com/v1/bpi/currentprice/USD.json');
+    const json = await res.json();
+    return parseFloat(json.bpi.USD.rate_float || json.bpi.USD.rate);
+  }
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      fetchBTCPrice().then((price) => {
+        setBtcHistory((prev) => [...prev.slice(-10), price]);
+      });
+    }, 10000);
+    return () => clearInterval(interval);
+  }, []);
+
   const dashboard = (
     <div className="bg-base text-white min-h-screen px-8 py-6">
       <h1 className="text-4xl font-bold text-anchor">SYOS Dashboard</h1>
       <WalletDisplay />
       <MemoryLog />
       <DriftChart />
+      <PriceChart data={btcHistory} />
     </div>
   );
 

--- a/syos_dapp_ui/src/components/PriceChart.tsx
+++ b/syos_dapp_ui/src/components/PriceChart.tsx
@@ -1,0 +1,34 @@
+import { Line } from 'react-chartjs-2';
+import { Chart as ChartJS, LineElement, CategoryScale, LinearScale, PointElement } from 'chart.js';
+
+ChartJS.register(LineElement, CategoryScale, LinearScale, PointElement);
+
+export default function PriceChart({ data }: { data: number[] }) {
+  const chartData = {
+    labels: data.map((_, i) => `T${i}`),
+    datasets: [
+      {
+        label: 'BTC Price',
+        data,
+        borderColor: '#39FF14',
+        backgroundColor: 'rgba(57, 255, 20, 0.2)',
+        tension: 0.4,
+      },
+    ],
+  };
+
+  const options = {
+    scales: {
+      x: { ticks: { color: '#39FF14' } },
+      y: { ticks: { color: '#39FF14' } },
+    },
+    plugins: {
+      legend: {
+        labels: { color: '#39FF14' },
+      },
+    },
+  };
+
+  return <Line data={chartData} options={options} />;
+}
+

--- a/syos_dapp_ui/src/index.css
+++ b/syos_dapp_ui/src/index.css
@@ -1,3 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+  @apply bg-bgDark text-neon font-neon;
+}

--- a/syos_dapp_ui/tailwind.config.js
+++ b/syos_dapp_ui/tailwind.config.js
@@ -2,10 +2,17 @@ module.exports = {
   content: ["./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
     extend: {
+      fontFamily: {
+        neon: ['Orbitron', 'sans-serif'],
+      },
       colors: {
         anchor: '#5F4B8B',
         drift: '#FF6B6B',
         base: '#101010',
+        neon: '#39FF14',
+        bgDark: '#0a0a0a',
+        card: '#1f1f1f',
+        accent: '#00FFF7',
       },
     },
   },


### PR DESCRIPTION
## Summary
- extend Tailwind theme with neon palette and custom font
- style body with neon defaults
- load Orbitron font in `index.html`
- add Chart.js dependencies and new `PriceChart` component
- display live BTC chart in the dashboard

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6869f3da63188323acffad198a58c53e