### PR TITLE
Ensure Tailwind bg-background utility

### DIFF
--- a/syos_dapp_ui/src/index.css
+++ b/syos_dapp_ui/src/index.css
@@ -2,6 +2,19 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  --color-background: #0d0d0d;
+  --color-neon: #00ffff;
+}
+
+@layer utilities {
+  .bg-background {
+    background-color: var(--color-background);
+  }
+}
+
 body {
-  @apply bg-background text-neon font-orbitron;
+  background-color: var(--color-background);
+  color: var(--color-neon);
+  font-family: 'Orbitron', sans-serif;
 }


### PR DESCRIPTION
## Summary
- define a CSS variable for background and neon colors
- add a custom `bg-background` rule via `@layer utilities`
- use variables directly in `body` to avoid apply errors

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686a057d49e883238da0b6718b764191