### PR TITLE
Add dark mode support

### DIFF
--- a/syos_dapp_ui/src/App.tsx
+++ b/syos_dapp_ui/src/App.tsx
@@ -8,7 +8,7 @@ import ChartComponent from "./components/ChartComponent";
 const App = () => {
 
   const dashboard = (
-    <div className="bg-background text-neon font-orbitron min-h-screen p-4 md:p-8">
+    <div className="dark bg-background text-neon font-orbitron min-h-screen p-4 md:p-8">
       <h1 className="text-4xl font-bold text-accent mb-4">SYOS Dashboard</h1>
       <div className="grid gap-4 md:grid-cols-2">
         <div className="md:col-span-2">

--- a/syos_dapp_ui/src/index.css
+++ b/syos_dapp_ui/src/index.css
@@ -18,3 +18,8 @@ body {
   color: var(--color-neon);
   font-family: 'Orbitron', sans-serif;
 }
+
+.dark body {
+  background-color: var(--color-background);
+  color: var(--color-neon);
+}

--- a/syos_dapp_ui/tailwind.config.js
+++ b/syos_dapp_ui/tailwind.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  darkMode: 'class',
   content: ["./src/**/*.{js,ts,jsx,tsx}", "./src/index.css"],
   theme: {
     extend: {


### PR DESCRIPTION
## Summary
- enable Tailwind dark mode
- style body when `.dark` class is present
- mark dashboard root div with `dark` class
- build and preview to verify the new mode

## Testing
- `npm run build`
- `npm run preview`

------
https://chatgpt.com/codex/tasks/task_e_686a16b49ac083238ba0be33cf786e8f