### PR TITLE
Add Jupiter swap quote utility and TradeExecutor

### DIFF
--- a/syos_dapp_ui/src/App.tsx
+++ b/syos_dapp_ui/src/App.tsx
@@ -4,6 +4,7 @@ import WalletDisplay from "./components/WalletDisplay";
 import MemoryLog from "./components/MemoryLog";
 import DriftChart from "./components/DriftChart";
 import ChartComponent from "./components/ChartComponent";
+import TradeExecutor from "./components/TradeExecutor";
 
 const App = () => {
 
@@ -17,6 +18,7 @@ const App = () => {
         <MemoryLog />
         <DriftChart />
         <ChartComponent />
+        <TradeExecutor />
       </div>
     </div>
   );

--- a/syos_dapp_ui/src/components/TradeExecutor.tsx
+++ b/syos_dapp_ui/src/components/TradeExecutor.tsx
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+import { getSwapQuote } from '../utils/jupiter';
+
+export default function TradeExecutor() {
+  const [quote, setQuote] = useState<any | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getSwapQuote({
+      inputMint: 'So11111111111111111111111111111111111111112',
+      outputMint: 'EPjFWdd5AufqSSqeM2qRFBwtDJewL9aZCLuDHic9xp8',
+      amount: 1000000, // 1 SOL (lamports)
+    })
+      .then(setQuote)
+      .catch((e: any) => setError(e.message));
+  }, []);
+
+  return (
+    <div>
+      <h2 className="text-xl mb-2">Swap Quote</h2>
+      {error && <p>Error: {error}</p>}
+      <pre className="whitespace-pre-wrap break-all text-xs">
+        {quote ? JSON.stringify(quote, null, 2) : 'Loading...'}
+      </pre>
+    </div>
+  );
+}

--- a/syos_dapp_ui/src/utils/jupiter.ts
+++ b/syos_dapp_ui/src/utils/jupiter.ts
@@ -1,0 +1,18 @@
+export interface SwapQuoteParams {
+  inputMint: string;
+  outputMint: string;
+  amount: number;
+}
+
+export async function getSwapQuote({ inputMint, outputMint, amount }: SwapQuoteParams) {
+  const params = new URLSearchParams({
+    inputMint,
+    outputMint,
+    amount: amount.toString(),
+  });
+  const res = await fetch(`https://quote-api.jup.ag/v6/quote?${params.toString()}`);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch quote: ${res.status}`);
+  }
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- add `getSwapQuote` helper using fetch
- add `TradeExecutor` component that fetches a quote and displays it
- show `TradeExecutor` in main dashboard
- build succeeds

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686a194bca388323a04e5b72c8993993