### PR TITLE
Add trait history and price charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,18 @@ Add these repository secrets so the workflow can authenticate:
 
 Once configured, pushes to `main` redeploy https://syos-system-fin.vercel.app.
 
+## Local Development & Deployment
+
+Run the dashboard locally with:
+
+```bash
+cd syos_dapp_ui
+npm install
+npm run dev
+# or create a production build
+npm run build
+```
+
+Deployments to Vercel read the `vercel.json` rewrite configuration so the React
+router, Tailwind styling and wallet adapters work together with the price chart.
+

--- a/syos_dapp_ui/src/App.tsx
+++ b/syos_dapp_ui/src/App.tsx
@@ -4,6 +4,7 @@ import WalletDisplay from "./components/WalletDisplay";
 import MemoryLog from "./components/MemoryLog";
 import DriftChart from "./components/DriftChart";
 import ChartComponent from "./components/ChartComponent";
+import PriceChart from "./components/PriceChart";
 import TradeExecutor from "./components/TradeExecutor";
 
 const App = () => {
@@ -18,6 +19,7 @@ const App = () => {
         <MemoryLog />
         <DriftChart />
         <ChartComponent />
+        <PriceChart />
         <TradeExecutor />
       </div>
     </div>

--- a/syos_dapp_ui/src/components/PriceChart.tsx
+++ b/syos_dapp_ui/src/components/PriceChart.tsx
@@ -1,34 +1,59 @@
+import { useEffect, useState } from 'react';
 import { Line } from 'react-chartjs-2';
 import { Chart as ChartJS, LineElement, CategoryScale, LinearScale, PointElement } from 'chart.js';
+import { getHistory, Coin, TraitEntry } from '../system/TraitDatabase';
 
 ChartJS.register(LineElement, CategoryScale, LinearScale, PointElement);
 
-export default function PriceChart({ data }: { data: number[] }) {
-  const chartData = {
-    labels: data.map((_, i) => `T${i}`),
-    datasets: [
-      {
-        label: 'BTC Price',
-        data,
-        borderColor: '#39FF14',
-        backgroundColor: 'rgba(57, 255, 20, 0.2)',
-        tension: 0.4,
-      },
-    ],
-  };
+const COLORS: Record<Coin, string> = {
+  BTC: '#39FF14',
+  ETH: '#ff00ff',
+  SOL: '#00ffff',
+};
 
+export default function PriceChart() {
+  const [data, setData] = useState<Record<Coin, TraitEntry[]>>({
+    BTC: getHistory('BTC'),
+    ETH: getHistory('ETH'),
+    SOL: getHistory('SOL'),
+  });
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setData({
+        BTC: getHistory('BTC'),
+        ETH: getHistory('ETH'),
+        SOL: getHistory('SOL'),
+      });
+    }, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const labels = data.BTC.map((e) => new Date(e.timestamp).toLocaleTimeString());
+  const datasets = (Object.keys(data) as Coin[]).map((coin) => ({
+    label: coin,
+    data: data[coin].map((e) => e.price),
+    borderColor: COLORS[coin],
+    backgroundColor: 'transparent',
+    tension: 0.4,
+  }));
+
+  const chartData = { labels, datasets };
   const options = {
     scales: {
       x: { ticks: { color: '#39FF14' } },
       y: { ticks: { color: '#39FF14' } },
     },
     plugins: {
-      legend: {
-        labels: { color: '#39FF14' },
-      },
+      legend: { labels: { color: '#39FF14' } },
     },
-  };
+    responsive: true,
+    maintainAspectRatio: false,
+  } as const;
 
-  return <Line data={chartData} options={options} />;
+  return (
+    <div className="bg-card p-2 h-48">
+      <Line data={chartData} options={options} />
+    </div>
+  );
 }
-

--- a/syos_dapp_ui/src/system/TraitDatabase.ts
+++ b/syos_dapp_ui/src/system/TraitDatabase.ts
@@ -1,0 +1,38 @@
+export interface TraitEntry {
+  timestamp: number;
+  price: number;
+  trait: string;
+}
+
+export type Coin = 'BTC' | 'ETH' | 'SOL';
+
+export const traitLog: Record<Coin, TraitEntry[]> = {
+  BTC: [],
+  ETH: [],
+  SOL: [],
+};
+
+export function addTrait(coin: Coin, price: number, trait: string, timestamp = Date.now()) {
+  traitLog[coin].push({ timestamp, price, trait });
+}
+
+export function getHistory(coin: Coin): TraitEntry[] {
+  return traitLog[coin];
+}
+
+// mock data for in-memory tests
+function seedMockData() {
+  const now = Date.now();
+  ['BTC', 'ETH', 'SOL'].forEach((c, idx) => {
+    const coin = c as Coin;
+    for (let i = 0; i < 10; i++) {
+      addTrait(
+        coin,
+        100 + idx * 50 + Math.random() * 10,
+        i % 2 === 0 ? 'bullish' : 'bearish',
+        now - (10 - i) * 60000
+      );
+    }
+  });
+}
+seedMockData();

--- a/syos_dapp_ui/vercel.json
+++ b/syos_dapp_ui/vercel.json
@@ -1,6 +1,5 @@
 {
   "rewrites": [
-    { "source": "/api/:path*", "destination": "/api/:path*" },
-    { "source": "/:path*", "destination": "/index.html" }
+    { "source": "/(.*)", "destination": "/" }
   ]
 }


### PR DESCRIPTION
## Summary
- store sample trait history in a new in-memory `TraitDatabase`
- render BTC/ETH/SOL sparkline using react-chartjs-2
- expose price chart on dashboard
- adjust Vercel rewrite rule
- document running and deploying the DApp

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686a3431aa7c8323a5bf0532023b06ef